### PR TITLE
list-handlers should list all handers

### DIFF
--- a/django_grpc/utils.py
+++ b/django_grpc/utils.py
@@ -55,23 +55,24 @@ def load_interceptors(strings) -> tuple:
 
 
 def extract_handlers(server):
-    for path, it in server._state.generic_handlers[0]._method_handlers.items():
-        unary = it.unary_unary
-        if unary is None:
-            name = "???"
-            params = "???"
-            abstract = 'DOES NOT EXIST'
-        else:
-            code = it.unary_unary.__code__
-            name = code.co_name
-            params = ", ".join(code.co_varnames)
-            abstract = ''
-            if isinstance(it.__class__, ABCMeta):
-                abstract = 'NOT IMPLEMENTED'
+    for handler in server._state.generic_handlers:
+        for path, it in handler._method_handlers.items():
+            unary = it.unary_unary
+            if unary is None:
+                name = "???"
+                params = "???"
+                abstract = 'DOES NOT EXIST'
+            else:
+                code = it.unary_unary.__code__
+                name = code.co_name
+                params = ", ".join(code.co_varnames)
+                abstract = ''
+                if isinstance(it.__class__, ABCMeta):
+                    abstract = 'NOT IMPLEMENTED'
 
-        yield "{path}: {name}({params}) {abstract}".format(
-            path=path,
-            name=name,
-            params=params,
-            abstract=abstract
-        )
+            yield "{path}: {name}({params}) {abstract}".format(
+                path=path,
+                name=name,
+                params=params,
+                abstract=abstract
+            )


### PR DESCRIPTION
I noticed that when starting the grpc server with `--list-handlers`, only the first registered handler would be listed. a quick look at the code revealed that an extra loop was required. 

I tried writing a test, but was not able to get output from the TestGRPCServer.  I'm happy to take suggestions on that front. 