### PR TITLE
Return a list from load_interceptors function instead of a tuple.

### DIFF
--- a/django_grpc/utils.py
+++ b/django_grpc/utils.py
@@ -78,14 +78,14 @@ def add_servicers(server, servicers_list):
         callback(ps)
 
 
-def load_interceptors(strings) -> tuple:
+def load_interceptors(strings) -> list:
     # Default interceptors
     result = []
     # User defined interceptors
     for path in strings:
         logger.debug("Initializing interceptor from %s", path)
         result.append(import_string(path)())
-    return tuple(result)
+    return result
 
 
 def extract_handlers(server):


### PR DESCRIPTION
In elastic-apm 6.14.0 grpc interceptor was added. On the elasticapm client instantiation it tries to add an interceptor at the start of interceptors list. It requires a list of interceptors to be a list, not a tuple:
![image](https://user-images.githubusercontent.com/11714274/216966019-d11238c5-92c3-4abb-ac18-836f37a226bc.png)
