### PR TITLE
Extend FakeServicerContext with abort tracking, aliases, deadline and typing

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include LICENSE
 include README.md
 recursive-include django_grpc *py
 recursive-include django_grpc_testtools *py
+include django_grpc_testtools/py.typed

--- a/README.md
+++ b/README.md
@@ -176,3 +176,12 @@ In addition to standard gRPC context methods, FakeServicerContext provides:
  * `.set_invocation_metadata()` allows to simulate metadata from client to server.
  * `.get_trailing_metadata()` to get metadata set by your server
  * `.abort_status` and `.abort_message` to check if `.abort()` was called 
+ * `.abort_called` tells whether `.abort()` was called at all. Unlike `.abort_status`, it
+   distinguishes "aborted with `StatusCode.UNKNOWN`" from "never aborted".
+ * `.abort_code` and `.aborted` are read/write aliases of `.abort_status` and `.abort_called`.
+ * `.set_time_remaining()` allows to simulate an RPC deadline, which `.time_remaining()` reports.
+   Defaults to 60 seconds.
+ * `.clear()` forgets the outcome of a call (abort state and trailing metadata) so that the same
+   context can be reused for another one. Invocation metadata and the deadline are preserved.
+
+The package ships a `py.typed` marker, so type checkers see the annotations above instead of `Any`.

--- a/django_grpc_testtools/context.py
+++ b/django_grpc_testtools/context.py
@@ -5,6 +5,11 @@ from collections.abc import Sequence, Mapping
 from grpc import ServicerContext
 
 MetadataType = Sequence[tuple[str, str]]
+
+#: Reported by FakeServicerContext.time_remaining() unless overridden via set_time_remaining().
+#: A finite default keeps servicer code that does arithmetic on the deadline working out of the box.
+DEFAULT_TIME_REMAINING = 60.0
+
 _NON_OK_RENDEZVOUS_REPR_FORMAT = (
     "<{} of RPC that terminated with:\n"
     "\tstatus = {}\n"
@@ -20,16 +25,54 @@ class FakeServicerContext(ServicerContext):
     for validation in tests
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.abort_status: StatusCode = StatusCode.UNKNOWN
         self.abort_message: str = ""
+        self.abort_called: bool = False
         self._invocation_metadata: MetadataType = tuple()
         self._trailing_metadata: Mapping[str, str] = dict()
+        self._time_remaining: float = DEFAULT_TIME_REMAINING
+
+    @property
+    def abort_code(self) -> StatusCode:
+        """
+        Alias of `abort_status`, readable and writable
+        """
+        return self.abort_status
+
+    @abort_code.setter
+    def abort_code(self, value: StatusCode) -> None:
+        self.abort_status = value
+
+    @property
+    def aborted(self) -> bool:
+        """
+        Alias of `abort_called`, readable and writable
+        """
+        return self.abort_called
+
+    @aborted.setter
+    def aborted(self, value: bool) -> None:
+        self.abort_called = value
+
+    def clear(self) -> None:
+        """
+        Forget what the servicer did, so that the same context can be reused for another call.
+
+        Only the outcome of the call is reset. Input supplied by the client (invocation metadata)
+        and the simulated deadline are preserved, because they describe the call to be made rather
+        than its result.
+        """
+        self.abort_status = StatusCode.UNKNOWN
+        self.abort_message = ""
+        self.abort_called = False
+        self._trailing_metadata = dict()
 
     def abort(self, status: StatusCode, message: str) -> NoReturn:
         """
         gRPC method that is called on RPC exit
         """
+        self.abort_called = True
         self.abort_status = status
         self.abort_message = message
         debug_error_string = (
@@ -72,6 +115,18 @@ class FakeServicerContext(ServicerContext):
         Helper to emulate request metadata
         """
         self._invocation_metadata = items
+
+    def time_remaining(self) -> float:
+        """
+        gRPC method that reports how many seconds are left before the RPC deadline
+        """
+        return self._time_remaining
+
+    def set_time_remaining(self, seconds: float) -> None:
+        """
+        Helper to emulate an RPC deadline
+        """
+        self._time_remaining = seconds
 
     def set_code(self, code: StatusCode) -> None:
         self.abort_status = code
@@ -129,9 +184,6 @@ class FakeServicerContext(ServicerContext):
         raise NotImplementedError()
 
     def is_active(self):
-        raise NotImplementedError()
-
-    def time_remaining(self):
         raise NotImplementedError()
 
     def cancel(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-grpc"
-version = "1.1.2"
+version = "1.2.0"
 description = "Easy gRPC service based on Django application"
 authors = ["Stan Misiurev <smisiurev@gmail.com>"]
 license = "MIT License"

--- a/tests/test_fake_servicer_context.py
+++ b/tests/test_fake_servicer_context.py
@@ -1,7 +1,9 @@
+from importlib.resources import files
+
 from grpc import RpcError, StatusCode, ServicerContext
 import pytest
 
-from django_grpc_testtools.context import FakeServicerContext
+from django_grpc_testtools.context import DEFAULT_TIME_REMAINING, FakeServicerContext
 
 
 def test_fake_servicer_context():
@@ -9,3 +11,107 @@ def test_fake_servicer_context():
     assert isinstance(context, ServicerContext)
     with pytest.raises(RpcError):
         context.abort(StatusCode.UNAVAILABLE, 'test')
+
+
+def test_abort_records_status_message_and_the_fact_that_it_was_called():
+    context = FakeServicerContext()
+    assert context.abort_called is False
+
+    with pytest.raises(RpcError):
+        context.abort(StatusCode.INVALID_ARGUMENT, 'Cannot say hello to John')
+
+    assert context.abort_called is True
+    assert context.abort_status == StatusCode.INVALID_ARGUMENT
+    assert context.abort_message == 'Cannot say hello to John'
+
+
+def test_abort_called_distinguishes_unknown_abort_from_no_abort():
+    """`abort_status` defaults to UNKNOWN, so it cannot answer "was abort called?" on its own."""
+    context = FakeServicerContext()
+    assert context.abort_status == StatusCode.UNKNOWN
+    assert context.abort_called is False
+
+    with pytest.raises(RpcError):
+        context.abort(StatusCode.UNKNOWN, 'boom')
+
+    assert context.abort_status == StatusCode.UNKNOWN
+    assert context.abort_called is True
+
+
+def test_abort_code_is_a_read_write_alias_of_abort_status():
+    context = FakeServicerContext()
+    assert context.abort_code == context.abort_status
+
+    context.abort_code = StatusCode.NOT_FOUND
+    assert context.abort_status == StatusCode.NOT_FOUND
+
+    context.set_code(StatusCode.PERMISSION_DENIED)
+    assert context.abort_code == StatusCode.PERMISSION_DENIED
+
+
+def test_aborted_is_a_read_write_alias_of_abort_called():
+    context = FakeServicerContext()
+    assert context.aborted is False
+
+    context.aborted = True
+    assert context.abort_called is True
+
+    context.abort_called = False
+    assert context.aborted is False
+
+
+def test_set_code_does_not_mark_the_context_as_aborted():
+    context = FakeServicerContext()
+    context.set_code(StatusCode.NOT_FOUND)
+    assert context.abort_called is False
+
+
+def test_clear_resets_the_outcome_but_keeps_the_inputs():
+    context = FakeServicerContext()
+    context.set_invocation_metadata((('key', 'value'),))
+    context.set_time_remaining(5.0)
+    context.set_trailing_metadata((('Header1', 'set-by-server'),))
+    with pytest.raises(RpcError):
+        context.abort(StatusCode.NOT_FOUND, 'nope')
+
+    context.clear()
+
+    # Outcome of the call is forgotten...
+    assert context.abort_called is False
+    assert context.abort_status == StatusCode.UNKNOWN
+    assert context.abort_message == ''
+    with pytest.raises(KeyError):
+        context.get_trailing_metadata('Header1')
+
+    # ...while what describes the call itself survives.
+    assert context.invocation_metadata() == (('key', 'value'),)
+    assert context.time_remaining() == 5.0
+
+
+def test_time_remaining_reports_the_simulated_deadline():
+    context = FakeServicerContext()
+    assert context.time_remaining() == DEFAULT_TIME_REMAINING
+
+    context.set_time_remaining(29.9)
+    assert context.time_remaining() == 29.9
+
+
+def test_invocation_metadata_round_trip():
+    context = FakeServicerContext()
+    assert context.invocation_metadata() == tuple()
+
+    context.set_invocation_metadata((('idempotency-key', 'abc123'),))
+    assert dict(context.invocation_metadata()) == {'idempotency-key': 'abc123'}
+
+
+def test_trailing_metadata_round_trip():
+    context = FakeServicerContext()
+    context.set_trailing_metadata((('Header1', 'value1'), ('Header2', 'value2')))
+
+    assert context.get_trailing_metadata('Header1') == 'value1'
+    assert context.get_trailing_metadata('Header2') == 'value2'
+
+
+def test_package_ships_py_typed_marker():
+    """Guards the packaging: without this file type checkers fall back to Any."""
+    assert files('django_grpc_testtools').joinpath('py.typed').is_file()


### PR DESCRIPTION
## Why

We use `FakeServicerContext` across ~20 Django services. Over time several of those services stopped
using it and grew their own copies instead, each to work around one small gap: no way to tell "aborted
with `UNKNOWN`" from "never aborted", `time_remaining()` raising instead of returning a deadline, and
`mypy` seeing every attribute as `Any` because the package ships no `py.typed`.

This PR closes those gaps so the shared class is usable again. Everything is additive — no existing
attribute or method changes meaning.

## What changed

- **`abort_called`** — a real `bool`, set inside `abort()` before it raises. It cannot be derived from
  the existing state: `abort_status` defaults to `StatusCode.UNKNOWN`, so `abort(UNKNOWN, ...)` and
  "never aborted" are indistinguishable today. `set_code()` deliberately does *not* set it — setting a
  status code is not aborting.
- **`abort_code` / `aborted`** — read/write properties aliasing `abort_status` / `abort_called`. Both
  spellings are in wide use across codebases; aliasing them means tests can move between projects
  without a rename. Writable because `set_code()` and direct assignment both occur in practice.
- **`clear()`** — forgets the outcome of a call (abort state, trailing metadata) so one context can be
  reused for another. Invocation metadata and the deadline are preserved on purpose: they describe the
  call to be made, not its result.
- **`time_remaining()` / `set_time_remaining()`** — the fake previously refused to fake a standard
  `RpcContext` method. Now it returns a settable `float`, defaulting to `DEFAULT_TIME_REMAINING = 60.0`.
  A finite default matters because servicer code does arithmetic on it (`min(context.time_remaining(), 30)`
  is a real pattern), and `None` would raise `TypeError` there.
- **`py.typed`** — added to `django_grpc_testtools` only, plus annotations on `__init__`. Verified with
  `mypy`: assigning an `int` to `abort_message` is now reported, and previously was not.

## Deliberately not included

- **No `py.typed` in `django_grpc`.** That package is unannotated, so marking it typed would start
  analysing it in every downstream project and produce a wave of new diagnostics for no benefit here.
  `django_grpc_testtools` is test-only code, which keeps the blast radius small.
- `send_initial_metadata` and `abort_with_status` still raise `NotImplementedError` — nothing in our
  estate calls them, and I would rather keep this PR narrow.

## Two things worth flagging

1. `time_remaining()` no longer raises `NotImplementedError`. If anyone relied on that, it is a
   behaviour change.
2. Adding `py.typed` means type checkers stop treating this module as `Any`, so downstream projects may
   see new (correct) errors on first upgrade.

## Tests

`tests/test_fake_servicer_context.py` goes from 1 test to 11, covering: abort recording and the raise,
both alias directions, `set_code()` not marking an abort, `clear()` semantics including what it
preserves, the deadline default and override, and both metadata round-trips (previously untested).
There is also a packaging guard asserting `py.typed` is present, so a future packaging change cannot
silently drop it.

I bumped the version to 1.2.0 since the change is additive and backwards compatible, but that is your
call — happy to drop that commit hunk if you would rather handle releases yourself.
